### PR TITLE
logback 로깅 작업 추가

### DIFF
--- a/logs/file/miniWas.log
+++ b/logs/file/miniWas.log
@@ -1,0 +1,2 @@
+04-10-2020 01:08:12.607 [35m[main][0;39m [34mINFO [0;39m com.nhn.miniwas.HttpServer.start - HostName:XL1041-P1, InetAddress:localhost/127.0.0.1, Port:80, DocumentRoot:C:\Users\topojs8\Downloads\mini-was
+2020-10-04 01:09:09.751 [main] INFO  com.nhn.miniwas.HttpServer - HostName:XL1041-P1, InetAddress:localhost/127.0.0.1, Port:80, DocumentRoot:C:\Users\topojs8\Downloads\mini-was

--- a/logs/file/miniWas.log.2020-10-03.log
+++ b/logs/file/miniWas.log.2020-10-03.log
@@ -1,0 +1,16 @@
+210  [main] INFO  com.nhn.miniwas.HttpServer - HostName:XL1041-P1, InetAddress:localhost/127.0.0.1, Port:80, DocumentRoot:C:\Users\topojs8\Downloads\mini-was
+199  [main] INFO  com.nhn.miniwas.HttpServer - HostName:XL1041-P1, InetAddress:localhost/127.0.0.1, Port:80, DocumentRoot:C:\Users\topojs8\Downloads\mini-was
+202  [main] INFO  com.nhn.miniwas.HttpServer - HostName:XL1041-P1, InetAddress:localhost/127.0.0.1, Port:80, DocumentRoot:C:\Users\topojs8\Downloads\mini-was
+227  [main] INFO  com.nhn.miniwas.HttpServer - HostName:XL1041-P1, InetAddress:localhost/127.0.0.1, Port:80, DocumentRoot:C:\Users\topojs8\Downloads\mini-was
+195  [main] INFO  com.nhn.miniwas.HttpServer - HostName:XL1041-P1, InetAddress:localhost/127.0.0.1, Port:80, DocumentRoot:C:\Users\topojs8\Downloads\mini-was
+214  [main] INFO  com.nhn.miniwas.HttpServer - HostName:XL1041-P1, InetAddress:localhost/127.0.0.1, Port:80, DocumentRoot:C:\Users\topojs8\Downloads\mini-was
+2115 [main] INFO  com.nhn.miniwas.HttpServer - HostName:XL1041-P1, InetAddress:localhost/127.0.0.1, Port:80, DocumentRoot:C:\Users\topojs8\Downloads\mini-was
+196  [main] INFO  com.nhn.miniwas.HttpServer - HostName:XL1041-P1, InetAddress:localhost/127.0.0.1, Port:80, DocumentRoot:C:\Users\topojs8\Downloads\mini-was
+234  [main] INFO  com.nhn.miniwas.HttpServer - HostName:XL1041-P1, InetAddress:localhost/127.0.0.1, Port:80, DocumentRoot:C:\Users\topojs8\Downloads\mini-was
+199  [main] INFO  com.nhn.miniwas.HttpServer - HostName:XL1041-P1, InetAddress:localhost/127.0.0.1, Port:80, DocumentRoot:C:\Users\topojs8\Downloads\mini-was
+201  [main] ERROR com.nhn.miniwas.HttpServer - Level:WARNING Error accepting connection Exception:{}
+224  [main] INFO  com.nhn.miniwas.HttpServer - HostName:XL1041-P1, InetAddress:localhost/127.0.0.1, Port:80, DocumentRoot:C:\Users\topojs8\Downloads\mini-was
+170  [main] INFO  com.nhn.miniwas.HttpServer - HostName:XL1041-P1, InetAddress:localhost/127.0.0.1, Port:80, DocumentRoot:C:\Users\topojs8\Downloads\mini-was
+03-10-2020 23:05:26.296 [35m[main][0;39m [34mINFO [0;39m com.nhn.miniwas.HttpServer.start - HostName:XL1041-P1, InetAddress:localhost/127.0.0.1, Port:80, DocumentRoot:C:\Users\topojs8\Downloads\mini-was
+03-10-2020 23:06:12.505 [35m[main][0;39m INFO  com.nhn.miniwas.HttpServer - HostName:XL1041-P1, InetAddress:localhost/127.0.0.1, Port:80, DocumentRoot:C:\Users\topojs8\Downloads\mini-was
+195  [main] INFO  com.nhn.miniwas.HttpServer - HostName:XL1041-P1, InetAddress:localhost/127.0.0.1, Port:80, DocumentRoot:C:\Users\topojs8\Downloads\mini-was

--- a/src/main/java/com/nhn/miniwas/HttpServer.java
+++ b/src/main/java/com/nhn/miniwas/HttpServer.java
@@ -43,7 +43,7 @@ public class HttpServer {
                     Runnable r = new RequestHandler(rootDirectory, documentDirectory, INDEX_FILE, connection);
                     pool.submit(r);
                 } catch (IOException ex) {
-                    logger.error("Level:{} Error accepting connection Exception:{}", Level.WARNING, ex);
+                    logger.error("Level:{} Error accepting connection Exception:{}", Level.WARNING, ex.getStackTrace());
                 }
             }
         }
@@ -96,7 +96,7 @@ public class HttpServer {
             HttpServer webserver = new HttpServer(rootDirectory);
             webserver.start();
         } catch (IOException ex) {
-            logger.error("Level:{} Server could not start Exception:{}", Level.SEVERE, ex);
+            logger.error("Level:{} Server could not start Exception:{}", Level.SEVERE, ex.getStackTrace());
         }
     }
 }

--- a/src/main/java/com/nhn/miniwas/RequestHandler.java
+++ b/src/main/java/com/nhn/miniwas/RequestHandler.java
@@ -48,7 +48,7 @@ public class RequestHandler implements Runnable {
             // if(connection.getInetAddress() == "testAdress") {}
 
         } catch (IOException e) {
-            logger.error(e.getMessage());
+            logger.error(String.valueOf(e.getStackTrace()));
         }
     }
 
@@ -105,7 +105,7 @@ public class RequestHandler implements Runnable {
                 httpResponse.error(fileName);
             }
         } catch (IOException ex) {
-            logger.error("Level:{} Server could not start RemoteSocketAddress:{}, Exception:{}", Level.WARNING, connection.getRemoteSocketAddress(), ex);
+            logger.error("Level:{} Server could not start RemoteSocketAddress:{}, Exception:{}", Level.WARNING, connection.getRemoteSocketAddress(), ex.getStackTrace());
         } finally {
             try {
                 connection.close();

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,14 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+<configuration scan="true" scanPeriod="30 seconds">
+
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
+
+    <property name="LOG_DIR" value="./logs/file"/>
+    <property name="LOG_PATH_NAME" value="${LOG_DIR}/miniWas.log"/>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>
-                %d{dd-MM-yyyy HH:mm:ss.SSS} %magenta([%thread]) %highlight(%-5level) %logger{36}.%M - %msg%n
-            </pattern>
+            <pattern>%-5level %logger{0} - %msg%n</pattern>
         </encoder>
     </appender>
 
-    <root level="info">
-        <appender-ref ref="STDOUT"/>
-    </root>g
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH_NAME}</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- daily rollover -->
+            <fileNamePattern>${LOG_PATH_NAME}.%d{yyyy-MM-dd}.log</fileNamePattern>
+
+            <!-- keep 30 days' worth of history -->
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <level value="error"/>
+        <appender-ref ref="console"/>
+        <appender-ref ref="FILE"/>
+    </root>
+    <logger name="com.nhn.miniwas" level="trace" additivity="false">
+        <level value="info"/>
+        <appender-ref ref="console"/>
+        <appender-ref ref="FILE"/>
+    </logger>
+
 </configuration>


### PR DESCRIPTION
- 로그 파일을 하루 단위로 분리
- 로그 내용에 따라 적절한 로그 레벨 적용 (error, info 분리)
- 오류 발생 시, StackTrace 전체를 로그 파일 쓰기